### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -24,7 +24,7 @@ from optparse import OptionParser
 if sys.platform == 'win32':
     def quote(c):
         if ' ' in c:
-            return '"%s"' % c # work around spawn lamosity on windows
+            return '"{0!s}"'.format(c) # work around spawn lamosity on windows
         else:
             return c
 else:
@@ -79,9 +79,9 @@ distribute_source = 'http://python-distribute.org/distribute_setup.py'
 def normalize_to_url(option, opt_str, value, parser):
     if value:
         if '://' not in value: # It doesn't smell like a URL.
-            value = 'file://%s' % (
+            value = 'file://{0!s}'.format(
                 urllib.pathname2url(
-                    os.path.abspath(os.path.expanduser(value))),)
+                    os.path.abspath(os.path.expanduser(value))))
         if opt_str == '--download-base' and not value.endswith('/'):
             # Download base needs a trailing slash to make the world happy.
             value += '/'

--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -30,13 +30,13 @@ class PromptCache:
             index = self.next_index
             self.next_index = index + 1
             self.prompts[prompt] = index
-            return """span.prompt%i:before {
-  content: "%s ";
-}
-""" % (index, prompt)
+            return """span.prompt{0:d}:before {{
+  content: "{1!s} ";
+}}
+""".format(index, prompt)
 
     def get_prompt_class(self, prompt):
-        return 'prompt%i' % self.prompts[prompt]
+        return 'prompt{0:d}'.format(self.prompts[prompt])
 
 
 cache = PromptCache()
@@ -94,7 +94,7 @@ class PromptDirective(rst.Directive):
                 for prompt in prompts:
                     if line.startswith(prompt):
                         if len(statement) > 0:
-                            html += '<span class="%s">%s</span>\n' % (
+                            html += '<span class="{0!s}">{1!s}</span>\n'.format(
                                 prompt_class,
                                 highlight(
                                     '\n'.join(statement),
@@ -110,7 +110,7 @@ class PromptDirective(rst.Directive):
                 statement.append(line)
             # Add last prompt
             if len(statement) > 0:
-                html += '<span class="%s">%s</span>\n' % (
+                html += '<span class="{0!s}">{1!s}</span>\n'.format(
                     prompt_class,
                     highlight(
                         '\n'.join(statement),
@@ -122,7 +122,7 @@ class PromptDirective(rst.Directive):
             for line in self.content:
                 statement.append(line)
                 if len(line) == 0 or not line[-1] == '\\':
-                    html += '<span class="%s">%s</span>\n' % (
+                    html += '<span class="{0!s}">{1!s}</span>\n'.format(
                         cache.get_prompt_class(prompt),
                         highlight(
                             '\n'.join(statement),
@@ -131,13 +131,13 @@ class PromptDirective(rst.Directive):
                         ).strip('\r\n')
                     )
                     if prompt is not None:
-                        latex += '\n%s %s' % (prompt, '\n'.join(statement))
+                        latex += '\n{0!s} {1!s}'.format(prompt, '\n'.join(statement))
                     else:
                         latex += '\n' + '\n'.join(statement)
                     statement = []
         else:
             for line in self.content:
-                html += '<span class="%s">%s</span>\n' % (
+                html += '<span class="{0!s}">{1!s}</span>\n'.format(
                     cache.get_prompt_class(prompt),
                     highlight(
                         line,
@@ -146,7 +146,7 @@ class PromptDirective(rst.Directive):
                     ).strip('\r\n')
                 )
                 if prompt is not None:
-                    latex += '\n%s %s' % (prompt, line)
+                    latex += '\n{0!s} {1!s}'.format(prompt, line)
                 else:
                     latex += '\n' + line
 


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:sbrunner:sphinx-prompt?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:sbrunner:sphinx-prompt?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)