### PR TITLE
Add ability to read and write parallel

### DIFF
--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -162,3 +162,7 @@ class PromptDirective(rst.Directive):
 def setup(app):
     app.add_directive('prompt', PromptDirective)
     app.connect('env-purge-doc', cache.clear)
+    return {
+        'parallel_read_safe': True,
+        'parallel_write_safe': True,
+    }


### PR DESCRIPTION
This allows users to use the `-j` option when running Sphinx with this extension.

I believe this should work, but I'm not 100% sure how it would interact with the cache behavior. I'm going to test it locally but I don't know if I'd really find a way to make it fail. 