### PR TITLE
Remove newlines from `setup(description=...)`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,9 +14,7 @@ tests_require = [
 setup(
     name='sphinx-prompt',
     version='1.2.0',
-    description="""
-Sphinx directive to add unselectable prompt
-""",
+    description="Sphinx directive to add unselectable prompt",
     long_description="`Sphinx directive to add unselectable prompt <https://github.com/sbrunner/sphinx-prompt>`_",
     classifiers=[
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
This package's `setup.py` uses a string containing newlines as `setup()`'s `description` parameter, thereby triggering the bug pypa/setuptools#1390 and causing the package's metadata to be malformed.  You can see the results of this malformation at https://pypi.org/project/sphinx-prompt/1.2.0/, with fields like the classifiers erroneously appearing in the package description rather than in the sidebar.  This PR removes the newlines from the string, thereby fixing the metadata.