### PR TITLE
Add `batch` and `powershell` languages

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ Supported language:
 
 - ``text`` (no pigments, default)
 - ``bash``
+- ``batch``
+- ``powershell``
 - ``python``
 - ``scala``
 
@@ -35,7 +37,10 @@ If modifier is auto, a comma-separated list of prompts to find in the statements
 Else the prompt to add on each statements, for Python and Bash language the end
 ``\`` is supported.
 
-Default to empty, ``$`` for bash language.
+Defaults to empty, except for the shell languages listed below:
+- ``bash`` - ``$``
+- ``batch`` - ``C:\>``
+- ``powershell`` - ``PS C:\>``
 
 Examples
 --------

--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -6,7 +6,7 @@ from docutils import nodes
 from docutils.parsers import rst
 from pygments import highlight
 from pygments.formatters import HtmlFormatter
-from pygments.lexers import BashLexer, PythonLexer, ScalaLexer, TextLexer
+from pygments.lexers import BashLexer, BatchLexer, PowerShellLexer, PythonLexer, ScalaLexer, TextLexer
 
 
 class PromptCache:
@@ -57,6 +57,10 @@ class PromptDirective(rst.Directive):
                 prompt = self.arguments[1]
             elif language == "bash":
                 prompt = "$"
+            elif language == "batch":
+                prompt = r"C:\\>"
+            elif language == "powershell":
+                prompt = r"PS C:\\>"
             if len(self.arguments) > 2:
                 modifiers = self.arguments[2].split(",")
             if "auto" in modifiers:
@@ -77,6 +81,10 @@ class PromptDirective(rst.Directive):
         Lexer = TextLexer
         if language == "bash":
             Lexer = BashLexer
+        elif language == "batch":
+            Lexer = BatchLexer
+        elif language == "powershell":
+            Lexer = PowerShellLexer
         elif language == "python":
             Lexer = PythonLexer
         elif language == "scala":
@@ -109,7 +117,7 @@ class PromptDirective(rst.Directive):
                     prompt_class,
                     highlight("\n".join(statement), Lexer(), HtmlFormatter(nowrap=True)).strip("\r\n"),
                 )
-        elif language in ["bash", "python"]:
+        elif language in ["bash", "batch", "powershell", "python"]:
             for line in self.content:
                 statement.append(line)
                 if len(line) == 0 or not line[-1] == "\\":


### PR DESCRIPTION
Fixes #64 
I went for `C:\>` and `PS C:\>` for prompts as they seemed to look somewhat better but I can change it to something else.

Here's a comparison of `PS>` vs `PS C:\>` and of `>` vs `C:\>`:
![chrome_2021-03-18_19-01-21](https://user-images.githubusercontent.com/6032823/111679345-7f8a4b00-8821-11eb-9ede-949d5ee7dc7e.png)
![chrome_2021-03-18_19-02-21](https://user-images.githubusercontent.com/6032823/111679347-80bb7800-8821-11eb-8ffc-bf3539c22e2b.png)

I'll also be looking into fixing issue #65 in a separate PR later today.