### PR TITLE
Allow to configure the prompt using options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ The prompt can be further customized in one of two ways:
 
     .. code::
 
-        .. prompt:: [<language> [<prompts> [<modifier>]]]
+        .. prompt:: [<language> [<prompts> [<modifiers>]]]
 
            <statements>
 
@@ -36,7 +36,7 @@ The prompt can be further customized in one of two ways:
         .. prompt::
             :language: <language>
             :prompts: <prompts>
-            :modifier: <modifier>
+            :modifiers: <modifiers>
 
            <statements>
 

--- a/README.rst
+++ b/README.rst
@@ -11,11 +11,47 @@ In ``conf.py`` add ``extensions += ['sphinx-prompt']``.
 Syntax
 ------
 
+A default prompt can be created using a ``prompt`` directive:
+
 .. code::
 
-    .. prompt:: [<language> [<prompts> [<modifier>]]]
+    .. prompt::
 
        <statements>
+
+The prompt can be further customized in one of two ways:
+
+- Using positional arguments:
+
+    .. code::
+
+        .. prompt:: [<language> [<prompts> [<modifier>]]]
+
+           <statements>
+
+- Using options:
+
+    .. code::
+
+        .. prompt::
+            :language: <language>
+            :prompts: <prompts>
+            :modifier: <modifier>
+
+           <statements>
+
+While these constructs generate the same output, the positional arguments cannot be used
+if you want to use a prompt that contains spaces. This is a limitation of reStructuredText.
+
+Positional arguments can be mixed with options **if** they don't overlap
+(so if you pass prompts using options, you can only pass the language using positional arguments):
+
+.. code::
+
+    .. prompt:: bash
+        :prompts: (cool_project) $
+
+       python -m pip install -U sphinx-prompt
 
 Language
 ~~~~~~~~
@@ -38,6 +74,7 @@ Else the prompt to add on each statements, for Python and Bash language the end
 ``\`` is supported.
 
 Defaults to empty, except for the shell languages listed below:
+
 - ``bash`` - ``$``
 - ``batch`` - ``C:\>``
 - ``powershell`` - ``PS C:\>``

--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -43,6 +43,13 @@ PROMPTS = {
     "batch": r"C:\\>",
     "powershell": r"PS C:\\>",
 }
+LEXERS = {
+    "bash": BashLexer,
+    "batch": BatchLexer,
+    "powershell": PowerShellLexer,
+    "python": PythonLexer,
+    "scala": ScalaLexer,
+}
 
 
 class PromptDirective(rst.Directive):
@@ -93,17 +100,7 @@ class PromptDirective(rst.Directive):
             html += '<style type="text/css">\n' + styles + "</style>"
         latex = "\\begin{Verbatim}[commandchars=\\\\\\{\\}]"
 
-        Lexer = TextLexer
-        if language == "bash":
-            Lexer = BashLexer
-        elif language == "batch":
-            Lexer = BatchLexer
-        elif language == "powershell":
-            Lexer = PowerShellLexer
-        elif language == "python":
-            Lexer = PythonLexer
-        elif language == "scala":
-            Lexer = ScalaLexer
+        Lexer = LEXERS.get(language, TextLexer)
 
         statement = []
         if "auto" in modifiers:

--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -129,7 +129,7 @@ class PromptDirective(rst.Directive):
                     prompt_class,
                     highlight("\n".join(statement), Lexer(), HtmlFormatter(nowrap=True)).strip("\r\n"),
                 )
-        elif language in ["bash", "batch", "powershell", "python"]:
+        elif language in ["bash", "python"]:
             for line in self.content:
                 statement.append(line)
                 if len(line) == 0 or not line[-1] == "\\":


### PR DESCRIPTION
Fixes #65 

The commit [`fd7156a`](https://github.com/sbrunner/sphinx-prompt/commit/fd7156ac04aa9799b4aec116ec6f52ecea72326b) addresses the issue introduced in #66 that I sadly haven't noticed before it got merged (see [comment](https://github.com/sbrunner/sphinx-prompt/pull/66#issuecomment-802277780))

Note: the examples at http://sbrunner.github.io/sphinx-prompt might also be worth updating but I'm not sure where is the source code used for generating the HTML (unless that's been done manually?)