### PR TITLE
Fix additional spaces after the prompt when using multiple

### DIFF
--- a/sphinx-prompt/__init__.py
+++ b/sphinx-prompt/__init__.py
@@ -106,7 +106,7 @@ class PromptDirective(rst.Directive):
                                 ),
                             )
                             statement = []
-                        line = line[len(prompt) :].rstrip()
+                        line = line[len(prompt) + 1 :].rstrip()
                         prompt_class = cache.get_prompt_class(prompt)
                         break
 


### PR DESCRIPTION
Fixes #68
A simple fix - the code was using `rstrip()` instead of `lstrip()`.

The example from the linked issue after applying this fix:
![image](https://user-images.githubusercontent.com/6032823/111705971-cc7e1980-8841-11eb-9e06-9d5d1d78def6.png)
