### PR TITLE
Set the auto-generated version to 0.0.0 to stop confusing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ strict = true
 
 [tool.poetry]
 name = "sphinx-prompt"
-version = "1.6.0"
+version = "0.0.0"
 description = "Sphinx directive to add unselectable prompt"
 readme = "README.rst"
 authors = ["Stéphane Brunner <stephane.brunner@gmail.com>"]


### PR DESCRIPTION
The version number is generated by `poetry-dynamic-versioning`.

Fix:  #377.